### PR TITLE
Exchange reserves improvements

### DIFF
--- a/contracts/interfaces/IvExchangeReserves.sol
+++ b/contracts/interfaces/IvExchangeReserves.sol
@@ -5,7 +5,14 @@ pragma solidity 0.8.2;
 import "./IvFlashSwapCallback.sol";
 
 interface IvExchangeReserves is IvFlashSwapCallback {
-    event ReservesExchanged();
+    event ReservesExchanged(
+        address jkPair1,
+        address ikPair1,
+        address jkPair2,
+        address ikPair2,
+        uint256 requiredBackAmount,
+        uint256 flashAmountOut
+    );
 
     function exchange(
         address jkPair1,

--- a/contracts/interfaces/IvExchangeReserves.sol
+++ b/contracts/interfaces/IvExchangeReserves.sol
@@ -5,6 +5,8 @@ pragma solidity 0.8.2;
 import "./IvFlashSwapCallback.sol";
 
 interface IvExchangeReserves is IvFlashSwapCallback {
+    event ReservesExchanged();
+
     function exchange(
         address jkPair1,
         address ikPair1,

--- a/contracts/interfaces/IvExchangeReserves.sol
+++ b/contracts/interfaces/IvExchangeReserves.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity 0.8.2;
+
+import "./IvFlashSwapCallback.sol";
+
+interface IvExchangeReserves is IvFlashSwapCallback {
+    function exchange(
+        address jkPair1,
+        address ikPair1,
+        address jkPair2,
+        address ikPair2,
+        uint256 flashAmountOut
+    ) external;
+}

--- a/contracts/interfaces/IvPair.sol
+++ b/contracts/interfaces/IvPair.sol
@@ -72,7 +72,7 @@ interface IvPair {
         address ikPair,
         address to,
         bytes calldata data
-    ) external returns (uint256 _amountIn);
+    ) external returns (address _token, uint256 _leftovers);
 
     function mint(address to) external returns (uint256 liquidity);
 

--- a/contracts/libraries/PoolAddress.sol
+++ b/contracts/libraries/PoolAddress.sol
@@ -5,7 +5,7 @@ pragma solidity 0.8.2;
 /// @title Provides functions for deriving a pool address from the factory and token
 library PoolAddress {
     bytes32 internal constant POOL_INIT_CODE_HASH =
-        0x4d4b6241778eb3a88fe727935c978cf68e37a52f1bacd9f37889286cc7180458;
+        0x27473a547978aea9ce895aeee3bb7454d70dd4ff66aceda5ad3f121dc934ee96;
 
     function orderAddresses(
         address tokenA,

--- a/contracts/libraries/PoolAddress.sol
+++ b/contracts/libraries/PoolAddress.sol
@@ -5,7 +5,7 @@ pragma solidity 0.8.2;
 /// @title Provides functions for deriving a pool address from the factory and token
 library PoolAddress {
     bytes32 internal constant POOL_INIT_CODE_HASH =
-        0x3ec06439008f0a1d222aff786d710be2aa0b049b3909b3d6f5c6899c5805ef2d;
+        0x4d4b6241778eb3a88fe727935c978cf68e37a52f1bacd9f37889286cc7180458;
 
     function orderAddresses(
         address tokenA,

--- a/contracts/libraries/PoolAddress.sol
+++ b/contracts/libraries/PoolAddress.sol
@@ -5,7 +5,7 @@ pragma solidity 0.8.2;
 /// @title Provides functions for deriving a pool address from the factory and token
 library PoolAddress {
     bytes32 internal constant POOL_INIT_CODE_HASH =
-        0x496c564a1cc5a88ce7f581aa70cc81db4d1583056fd4de5270301e8b7511b39f;
+        0x687f068184c45d2d62beb0032be3af6d83390dc0f8dde2bc7439a2c4f11b84a2;
 
     function orderAddresses(
         address tokenA,

--- a/contracts/libraries/PoolAddress.sol
+++ b/contracts/libraries/PoolAddress.sol
@@ -5,7 +5,7 @@ pragma solidity 0.8.2;
 /// @title Provides functions for deriving a pool address from the factory and token
 library PoolAddress {
     bytes32 internal constant POOL_INIT_CODE_HASH =
-        0x27473a547978aea9ce895aeee3bb7454d70dd4ff66aceda5ad3f121dc934ee96;
+        0x496c564a1cc5a88ce7f581aa70cc81db4d1583056fd4de5270301e8b7511b39f;
 
     function orderAddresses(
         address tokenA,

--- a/contracts/types.sol
+++ b/contracts/types.sol
@@ -23,6 +23,7 @@ struct ExchangeReserveCallbackParams {
     address ikPair1;
     address jkPair2;
     address ikPair2;
+    address caller;
     uint256 flashAmountOut;
 }
 

--- a/contracts/types.sol
+++ b/contracts/types.sol
@@ -20,8 +20,10 @@ struct VirtualPoolTokens {
 
 struct ExchangeReserveCallbackParams {
     address jkPair1;
+    address ikPair1;
     address jkPair2;
     address ikPair2;
+    uint256 flashAmountOut;
 }
 
 struct SwapCallbackData {

--- a/contracts/vExchangeReserves.sol
+++ b/contracts/vExchangeReserves.sol
@@ -3,9 +3,9 @@ pragma solidity 0.8.2;
 
 import "./types.sol";
 import "./interfaces/IvPair.sol";
-import "./interfaces/IvFlashSwapCallback.sol";
+import "./interfaces/IvExchangeReserves.sol";
 
-contract vExchangeReserves is IvFlashSwapCallback {
+contract vExchangeReserves is IvExchangeReserves {
     address immutable factory;
 
     constructor(address _factory) {
@@ -37,7 +37,7 @@ contract vExchangeReserves is IvFlashSwapCallback {
         address jkPair2,
         address ikPair2,
         uint256 flashAmountOut
-    ) external {
+    ) external override {
         IvPair(jkPair1).swapNativeToReserve(
             flashAmountOut,
             ikPair1,

--- a/contracts/vExchangeReserves.sol
+++ b/contracts/vExchangeReserves.sol
@@ -35,14 +35,20 @@ contract vExchangeReserves is IvFlashSwapCallback {
         address jkPair1,
         address ikPair1,
         address jkPair2,
-        uint256 flashAmountOut,
-        bytes calldata swapCallbackData
+        address ikPair2,
+        uint256 flashAmountOut
     ) external {
         IvPair(jkPair1).swapNativeToReserve(
             flashAmountOut,
             ikPair1,
             jkPair2,
-            swapCallbackData
+            abi.encode(
+                ExchangeReserveCallbackParams({
+                    jkPair1: jkPair1,
+                    jkPair2: jkPair2,
+                    ikPair2: ikPair2
+                })
+            )
         );
     }
 }

--- a/contracts/vExchangeReserves.sol
+++ b/contracts/vExchangeReserves.sol
@@ -4,8 +4,9 @@ pragma solidity 0.8.2;
 import "./types.sol";
 import "./interfaces/IvPair.sol";
 import "./interfaces/IvExchangeReserves.sol";
+import "./base/multicall.sol";
 
-contract vExchangeReserves is IvExchangeReserves {
+contract vExchangeReserves is IvExchangeReserves, Multicall {
     address immutable factory;
 
     constructor(address _factory) {

--- a/contracts/vExchangeReserves.sol
+++ b/contracts/vExchangeReserves.sol
@@ -50,5 +50,7 @@ contract vExchangeReserves is IvExchangeReserves {
                 })
             )
         );
+
+        emit ReservesExchanged();
     }
 }

--- a/contracts/vExchangeReserves.sol
+++ b/contracts/vExchangeReserves.sol
@@ -30,6 +30,15 @@ contract vExchangeReserves is IvExchangeReserves, Multicall {
             decodedData.jkPair1,
             new bytes(0)
         );
+
+        emit ReservesExchanged(
+            decodedData.jkPair1,
+            decodedData.ikPair1,
+            decodedData.jkPair2,
+            decodedData.ikPair2,
+            requiredBackAmount,
+            decodedData.flashAmountOut
+        );
     }
 
     function exchange(
@@ -46,12 +55,12 @@ contract vExchangeReserves is IvExchangeReserves, Multicall {
             abi.encode(
                 ExchangeReserveCallbackParams({
                     jkPair1: jkPair1,
+                    ikPair1: ikPair1,
                     jkPair2: jkPair2,
-                    ikPair2: ikPair2
+                    ikPair2: ikPair2,
+                    flashAmountOut: flashAmountOut
                 })
             )
         );
-
-        emit ReservesExchanged();
     }
 }

--- a/contracts/vExchangeReserves.sol
+++ b/contracts/vExchangeReserves.sol
@@ -7,6 +7,7 @@ import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
 import "./types.sol";
 import "./interfaces/IvPair.sol";
 import "./interfaces/IvExchangeReserves.sol";
+import "./interfaces/IvPairFactory.sol";
 import "./base/multicall.sol";
 
 contract vExchangeReserves is IvExchangeReserves, Multicall {
@@ -58,6 +59,13 @@ contract vExchangeReserves is IvExchangeReserves, Multicall {
         address ikPair2,
         uint256 flashAmountOut
     ) external override {
+        address _jkToken0;
+        address _jkToken1;
+        (_jkToken0, _jkToken1) = IvPair(jkPair1).getTokens();
+        require(IvPairFactory(factory).getPair(_jkToken0, _jkToken1) != address(0), 'IJKP1');
+        (_jkToken0, _jkToken1) = IvPair(jkPair2).getTokens();
+        require(IvPairFactory(factory).getPair(_jkToken0, _jkToken1) != address(0), 'IJKP2');
+
         IvPair(jkPair1).swapNativeToReserve(
             flashAmountOut,
             ikPair1,

--- a/contracts/vExchangeReserves.sol
+++ b/contracts/vExchangeReserves.sol
@@ -27,6 +27,8 @@ contract vExchangeReserves is IvExchangeReserves, Multicall {
             (ExchangeReserveCallbackParams)
         );
 
+        require(msg.sender == decodedData.jkPair1, 'IC');
+
         address _token;
         uint256 _leftovers;
         (_token, _leftovers) = IvPair(decodedData.jkPair2).swapNativeToReserve(

--- a/contracts/vExchangeReserves.sol
+++ b/contracts/vExchangeReserves.sol
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity 0.8.2;
 
+import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
+
 import "./types.sol";
 import "./interfaces/IvPair.sol";
 import "./interfaces/IvExchangeReserves.sol";
@@ -24,12 +27,16 @@ contract vExchangeReserves is IvExchangeReserves, Multicall {
             (ExchangeReserveCallbackParams)
         );
 
-        IvPair(decodedData.jkPair2).swapNativeToReserve(
+        address _token;
+        uint256 _leftovers;
+        (_token, _leftovers) = IvPair(decodedData.jkPair2).swapNativeToReserve(
             requiredBackAmount,
             decodedData.ikPair2,
             decodedData.jkPair1,
             new bytes(0)
         );
+
+        SafeERC20.safeTransfer(IERC20(_token), msg.sender, _leftovers);
 
         emit ReservesExchanged(
             decodedData.jkPair1,

--- a/contracts/vExchangeReserves.sol
+++ b/contracts/vExchangeReserves.sol
@@ -29,16 +29,17 @@ contract vExchangeReserves is IvExchangeReserves, Multicall {
 
         require(msg.sender == decodedData.jkPair1, 'IC');
 
-        address _token;
-        uint256 _leftovers;
-        (_token, _leftovers) = IvPair(decodedData.jkPair2).swapNativeToReserve(
+        address _leftoverToken;
+        uint256 _leftoverAmount;
+        (_leftoverToken, _leftoverAmount) = IvPair(decodedData.jkPair2).swapNativeToReserve(
             requiredBackAmount,
             decodedData.ikPair2,
             decodedData.jkPair1,
             new bytes(0)
         );
 
-        SafeERC20.safeTransfer(IERC20(_token), decodedData.caller, _leftovers);
+        if (_leftoverAmount > 0)
+            SafeERC20.safeTransfer(IERC20(_leftoverToken), decodedData.caller, _leftoverAmount);
 
         emit ReservesExchanged(
             decodedData.jkPair1,

--- a/contracts/vExchangeReserves.sol
+++ b/contracts/vExchangeReserves.sol
@@ -38,7 +38,7 @@ contract vExchangeReserves is IvExchangeReserves, Multicall {
             new bytes(0)
         );
 
-        SafeERC20.safeTransfer(IERC20(_token), msg.sender, _leftovers);
+        SafeERC20.safeTransfer(IERC20(_token), decodedData.caller, _leftovers);
 
         emit ReservesExchanged(
             decodedData.jkPair1,
@@ -67,7 +67,8 @@ contract vExchangeReserves is IvExchangeReserves, Multicall {
                     ikPair1: ikPair1,
                     jkPair2: jkPair2,
                     ikPair2: ikPair2,
-                    flashAmountOut: flashAmountOut
+                    flashAmountOut: flashAmountOut,
+                    caller: msg.sender
                 })
             )
         );

--- a/contracts/vPair.sol
+++ b/contracts/vPair.sol
@@ -201,6 +201,12 @@ contract vPair is IvPair, vSwapERC20, ReentrancyGuard {
     {
         require(amountOut > 0, 'IAO');
         require(to > address(0) && to != token0 && to != token1, 'IT');
+        // validate jkPair with factory
+        require(
+            IvPairFactory(factory).getPair(token0, token1) ==
+                address(this),
+            'IJKP'
+        );
 
         VirtualPoolModel memory vPool = vSwapLibrary.getVirtualPool(
             ikPair,

--- a/contracts/vPair.sol
+++ b/contracts/vPair.sol
@@ -201,11 +201,6 @@ contract vPair is IvPair, vSwapERC20, ReentrancyGuard {
     {
         require(amountOut > 0, 'IAO');
         require(to > address(0) && to != token0 && to != token1, 'IT');
-        // validate jkPair with factory
-        require(
-            IvPairFactory(factory).getPair(token0, token1) == address(this),
-            'IJKP'
-        );
 
         VirtualPoolModel memory vPool = vSwapLibrary.getVirtualPool(
             ikPair,

--- a/test/2_vPair.test.ts
+++ b/test/2_vPair.test.ts
@@ -316,7 +316,7 @@ describe('vPair1', () => {
         let reservesAfter0 = reservesAfter._balance0;
         let reservesAfter1 = reservesAfter._balance1;
 
-        expect(reservesAfter0).to.equal(10655); // 598 = MINIUMUM LOCKED LIQUIDITY
+        expect(reservesAfter0).to.equal(578); // 598 = MINIUMUM LOCKED LIQUIDITY
         expect(reservesAfter1).to.equal(1734); // 1733 = MINIUMUM LOCKED LIQUIDITY
     });
 

--- a/test/4_reserveRatio.test.ts
+++ b/test/4_reserveRatio.test.ts
@@ -773,12 +773,6 @@ describe("Reserve Ratio 2", () => {
 
     let amountDInReserve = await abPool.reserves(tokenD.address);
 
-    let data = utils.getEncodedExchangeReserveCallbackParams(
-      abPool.address, //jk1
-      bdPool.address, //jk2
-      abPool.address //ik2
-    );
-
     let BDRRBefore = await bdPool.calculateReserveRatio();
     console.log(`Reserve ratio of BD pool before = ${BDRRBefore.toString()}`);
 
@@ -791,8 +785,8 @@ describe("Reserve Ratio 2", () => {
       abPool.address, //jk1
       bdPool.address, // ik1
       bdPool.address, //jk2
+      abPool.address, //ik2
       amountDInReserve,
-      data
     );
 
     let BDRRAfter = await bdPool.calculateReserveRatio();

--- a/test/5_exchangeReserves.test.ts
+++ b/test/5_exchangeReserves.test.ts
@@ -104,12 +104,6 @@ describe("ExchangeReserves", () => {
 
     let amountAInReserve = await bcPool.reserves(tokenA.address);
 
-    let data = utils.getEncodedExchangeReserveCallbackParams(
-      bcPool.address, //jk1
-      abPool.address, //jk2
-      bcPool.address //ik2
-    );
-
     await tokenC.transfer(bcPool.address, ethers.utils.parseEther("10"));
 
     let aReserveInBC = await bcPool.reserves(tokenA.address);
@@ -126,8 +120,8 @@ describe("ExchangeReserves", () => {
       bcPool.address, //jk1
       abPool.address, // ik1
       abPool.address, //jk2
+      bcPool.address, // ik2
       amountAInReserve,
-      data
     );
 
     let tokenAReserveBaseValueAfter = await bcPool.reservesBaseValue(

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -13,12 +13,15 @@ export default {
   },
   getEncodedExchangeReserveCallbackParams: function (
     jkPair1: any,
+    ikPair1: any,
     jkPair2: any,
-    ikPair2: any
+    ikPair2: any,
+    caller: any,
+    flashAmountOut: any
   ) {
     return abi.encode(
-      ["address", "address", "address"],
-      [jkPair1, jkPair2, ikPair2]
+      ["address", "address", "address", "address", "address", "uint256"],
+      [jkPair1, ikPair1, jkPair2, ikPair2, caller, flashAmountOut]
     );
   },
 };


### PR DESCRIPTION
- Added multicall interface
- Added validation for jkPair to prevent using fake pair transmission from ExchangeReserve call
- Encoded ExchangeReserveCallbackParams in contract instead of asking it in API signature
- Added a new event ExchangeReserve
- Added incentives to caller for exchanging reserves